### PR TITLE
feat: wire RegisterContactCommand in API endpoints

### DIFF
--- a/apps/api/src/app/contacts/contacts.controller.ts
+++ b/apps/api/src/app/contacts/contacts.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { RegisterContactDto } from '@effectiv-crm/application';
+import { ContactsService } from './contacts.service';
+
+@Controller('contacts')
+export class ContactsController {
+  constructor(private readonly contactsService: ContactsService) {}
+
+  @Post('register')
+  async registerContact(@Body() dto: RegisterContactDto): Promise<void> {
+    await this.contactsService.registerContact(dto);
+  }
+}

--- a/apps/api/src/app/contacts/contacts.module.ts
+++ b/apps/api/src/app/contacts/contacts.module.ts
@@ -1,15 +1,20 @@
 import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
-import { ContactProjection } from '@effectiv-crm/application';
+import { ContactProjection, RegisterContactCommandHandler } from '@effectiv-crm/application';
 import { InMemoryContactProjection } from '@effectiv-crm/infrastructure';
 import { EventsModule } from '../events.module';
+import { ContactsController } from './contacts.controller';
+import { ContactsService } from './contacts.service';
 
 @Module({
   imports: [
     CqrsModule,
     EventsModule
   ],
+  controllers: [ContactsController],
   providers: [
+    ContactsService,
+    RegisterContactCommandHandler,
     // Projection
     {
       provide: ContactProjection,

--- a/apps/api/src/app/contacts/contacts.service.ts
+++ b/apps/api/src/app/contacts/contacts.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { CommandBus } from '@nestjs/cqrs';
+import { RegisterContactCommand, RegisterContactDto } from '@effectiv-crm/application';
+
+@Injectable()
+export class ContactsService {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  async registerContact(dto: RegisterContactDto): Promise<void> {
+    const command = new RegisterContactCommand(dto);
+    await this.commandBus.execute(command);
+  }
+}


### PR DESCRIPTION
This PR integrates the RegisterContactCommand into the API layer, providing a REST endpoint for contact registration.

## Changes
- Add ContactsController with POST /contacts/register endpoint
- Add ContactsService to handle command execution via CQRS CommandBus
- Update ContactsModule to register new controller, service, and command handler
- Follows existing patterns from LeadsController and LeadsService

## Testing
- Build passes successfully
- Lint passes successfully
- Follows NestJS and Clean Architecture patterns

## API Endpoint
- **POST** 
- **Body**: RegisterContactDto (name, email, phone, company)
- **Response**: 200 OK (void)